### PR TITLE
:dizzy_face: missing the link from requirements-dev to requirements file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+-r requirements.txt


### PR DESCRIPTION
If the file `requirements-dev.txt` do not point to `requirements.txt` file, it will never install the prod dependencies.